### PR TITLE
Fixed issues with exception in recurrent event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-calendar",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1504,6 +1504,19 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "ical-expander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ical-expander/-/ical-expander-2.0.0.tgz",
+      "integrity": "sha512-DABFhfEl0c58MeiTbG8hO5VEWQfKlFA7jSqdoIbS2caxS4nGyA73nVBGsFtIbmTrDO7Osgw9/up2ZCnvuxGcKA==",
+      "requires": {
+        "ical.js": "^1.2.2"
+      }
+    },
+    "ical.js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.3.0.tgz",
+      "integrity": "sha512-wQ0w77MGOe6vNhZMBQuZAtZoTzDEOQ/QoCDofWL7yfkQ/HYWX5NyWPYjN+yj+4JahOvTkhXjTlrZtiQKv+BSOA=="
     },
     "iconv-lite": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,14 +236,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "requires": {
-        "readable-stream": "~2.0.5"
-      }
-    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -1284,19 +1276,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "^1.0.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -1639,17 +1618,6 @@
         "is-path-inside": "^1.0.0"
       }
     },
-    "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -1695,11 +1663,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -1869,11 +1832,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2219,147 +2177,6 @@
       "requires": {
         "chalk": "^1.1.1",
         "lodash": "^4.2.0"
-      }
-    },
-    "node-ical": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.5.4.tgz",
-      "integrity": "sha1-my0GWJ7+sExgVJHSrBeXjiWaah0=",
-      "requires": {
-        "node-uuid": "^1.4.1",
-        "request": "2.75.0",
-        "rrule": "2.1.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "form-data": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
-          "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "qs": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-        },
-        "request": {
-          "version": "2.75.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
-          "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.0.0",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
       }
     },
     "node-status-codes": {
@@ -4875,11 +4692,6 @@
         "glob": "^7.0.5"
       }
     },
-    "rrule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.1.0.tgz",
-      "integrity": "sha1-bFs2meLlSfHfwmCf5+z2HI660pE="
-    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -6098,11 +5910,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "clone": "^2.1.1",
+    "ical-expander": "^2.0.0",
     "moment": "^2.22.1",
     "node-ical": "^0.5.4",
     "relative-time-parser": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "clone": "^2.1.1",
     "ical-expander": "^2.0.0",
     "moment": "^2.22.1",
-    "node-ical": "^0.5.4",
     "relative-time-parser": "^1.0.9",
     "request": "^2.85.0"
   },

--- a/src/CalendarActionBuilder.js
+++ b/src/CalendarActionBuilder.js
@@ -75,9 +75,6 @@ class CalendarActionBuilder {
   }
 
   _filterExpiredEvents(events, now) {
-
-    console.log(now);
-
     // Keep only events that expire right now or in the future
     return events.filter(event => event.expires.valueOf() >= now);
   }

--- a/src/CalendarActionBuilder.js
+++ b/src/CalendarActionBuilder.js
@@ -28,8 +28,6 @@ class CalendarActionBuilder {
     allEvents = this._sortEventsByDate(allEvents);
     allEvents = this._filterExpiredEvents(allEvents, now);
 
-    console.log(JSON.stringify(allEvents));
-
     return allEvents;
   }
 

--- a/src/CalendarActionBuilder.js
+++ b/src/CalendarActionBuilder.js
@@ -28,67 +28,45 @@ class CalendarActionBuilder {
     allEvents = this._sortEventsByDate(allEvents);
     allEvents = this._filterExpiredEvents(allEvents, now);
 
+    console.log(JSON.stringify(allEvents));
+
     return allEvents;
   }
 
   _generateNonRecurringEvents(cal) {
-    const events = [];
 
-    for (const key in cal) {
-      if (cal.hasOwnProperty(key)) {
-        const event = cal[key];
-        if (event.type === 'VEVENT' && event.rrule === undefined) {
-          events.push({
-            date: moment(event.start).relativeTime(this._startOffset).toDate(),
-            expires: event.end,
-            state: true,
-            summary: event.summary
-          });
-          events.push({
-            date: event.end,
-            expires: event.end,
-            state: false,
-            summary: event.summary
-          });
-        }
-      }
-    }
+    const events = [].concat(cal.events.map(e => ({
+        date: moment(e.startDate.toJSDate()).relativeTime(this._startOffset).toDate(),
+        expires: e.endDate.toJSDate(),
+        state: true,
+        summary: e.summary
+      })),
+      cal.events.map(e => ({
+        date: e.endDate.toJSDate(),
+        expires: e.endDate.toJSDate(),
+        state: false,
+        summary: e.summary
+      }))
+    );
 
     return events;
   }
 
   _generateRecurringEvents(cal, now) {
-    const events = [];
 
-    for (const key in cal) {
-      if (cal.hasOwnProperty(key)) {
-        const event = cal[key];
-        if (event.type === 'VEVENT' && event.rrule !== undefined) {
-          const duration = event.end - event.start;
-
-          const rstart = now.clone().subtract(2 * duration, 'milliseconds').toDate();
-          const rend = now.clone().add(7, 'days').toDate();
-
-          const expandedStartDates = event.rrule.between(rstart, rend, true);
-
-          for (const startDate of expandedStartDates) {
-            const endDate = new Date(startDate.valueOf() + duration);
-            events.push({
-              date: moment(startDate).relativeTime(this._startOffset).toDate(),
-              expires: endDate,
-              state: true,
-              summary: event.summary
-            });
-            events.push({
-              date: endDate,
-              expires: endDate,
-              state: false,
-              summary: event.summary
-            });
-          }
-        }
-      }
-    }
+    const events = [].concat(cal.occurrences.map(e => ({
+        date: moment(e.startDate.toJSDate()).relativeTime(this._startOffset).toDate(),
+        expires: e.endDate.toJSDate(),
+        state: true,
+        summary: e.summary
+      })),
+      cal.occurrences.map(e => ({
+        date: e.endDate.toJSDate(),
+        expires: e.endDate.toJSDate(),
+        state: false,
+        summary: e.summary
+      }))
+    );
 
     return events;
   }
@@ -99,6 +77,9 @@ class CalendarActionBuilder {
   }
 
   _filterExpiredEvents(events, now) {
+
+    console.log(now);
+
     // Keep only events that expire right now or in the future
     return events.filter(event => event.expires.valueOf() >= now);
   }

--- a/src/CalendarPoller.js
+++ b/src/CalendarPoller.js
@@ -79,7 +79,7 @@ class CalendarPoller extends EventEmitter {
     var next = new Date(now.getTime() + duration * 24 * 60 * 60 * 1000)
 
     const cal = icalExpander.between(now, next);
-    this._printEvent(cal);
+    //this._printEvent(cal);
 
     if (cal) {
       this.emit('data', cal);

--- a/src/CalendarPoller.js
+++ b/src/CalendarPoller.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
-
-const ical = require('node-ical');
+const IcalExpander = require('ical-expander');
+const https = require('https');
+const fs = require('fs');
 
 class CalendarPoller extends EventEmitter {
 
@@ -12,7 +13,7 @@ class CalendarPoller extends EventEmitter {
     this.log = log;
     this.name = name;
 
-    this._url = url.replace('webcal://', 'http://');
+    this._url = url.replace('webcal://', 'https://');
     this._interval = interval;
     this._isStarted = false;
   }
@@ -38,18 +39,53 @@ class CalendarPoller extends EventEmitter {
   _loadCalendar() {
     // TODO: Make use of HTTP cache control stuff
     this.log(`Updating calendar ${this.name}`);
-    ical.fromURL(this._url, {}, (err, cal) => {
+
+    https.get(this._url, (resp) => {
+
+      resp.setEncoding('utf8');
+      let data = '';
+  
+      // A chunk of data has been recieved.
+      resp.on('data', (chunk) => {
+          data += chunk;
+      });
+  
+      // The whole response has been received. Print out the result.
+      resp.on('end', () => {
+          fs.writeFileSync('./data.ics', data);
+          this._refreshCalendar();
+      });
+  
+    }).on("error", (err) => {
+
       if (err) {
         this.log(`Failed to load iCal calender: ${this.url} with error ${err}`);
         this.emit('error', err);
       }
 
-      if (cal) {
-        this.emit('data', cal);
-      }
-
-      this._scheduleNextIteration();
     });
+  }
+
+  _refreshCalendar() {
+
+    const ics = fs.readFileSync('./data.ics', 'utf-8');
+    const icalExpander = new IcalExpander({
+        ics,
+        maxIterations: 1000
+    });
+
+    const duration = 7; // days
+    var now = new Date();
+    var next = new Date(now.getTime() + duration * 24 * 60 * 60 * 1000)
+
+    const cal = icalExpander.between(now, next);
+    this._printEvent(cal);
+
+    if (cal) {
+      this.emit('data', cal);
+    }
+
+    this._scheduleNextIteration();
   }
 
   _scheduleNextIteration() {
@@ -61,6 +97,27 @@ class CalendarPoller extends EventEmitter {
       this._refreshTimer = undefined;
       this._loadCalendar();
     }, this._interval);
+  }
+
+  _printEvent(events) {
+
+    const mappedEvents = events.events.map(e => ({
+      startDate: e.startDate,
+      endDate: e.endDate,
+      summary: e.summary
+    }));
+
+    const mappedOccurrences = events.occurrences.map(o => ({
+      startDate: o.startDate,
+      endDate: o.endDate,
+      summary: o.item.summary
+    }));
+
+    const allEvents = [].concat(mappedEvents, mappedOccurrences);
+
+    console.log(allEvents.map(e => `${e.startDate.toJSDate().toISOString()} to ${e.endDate.toJSDate().toISOString()} - ${e.summary}`).join('\n'));
+
+
   }
 }
 


### PR DESCRIPTION
The node-ical library was not dealing correctly with exceptions to recurrent events.
I fixed it by replacing it with the ical-expander lib. This library directly delivers a list of occurrence of the event over the requested timespan taking into account all kind of exception (deleted and modified events).

Tested with both Google Calendar and iCloud calendars.