### PR TITLE
Add support for gzip encoded responses

### DIFF
--- a/src/CalendarPoller.js
+++ b/src/CalendarPoller.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const IcalExpander = require('ical-expander');
 const https = require('https');
+const zlib = require("zlib");
 
 class CalendarPoller extends EventEmitter {
 
@@ -40,6 +41,11 @@ class CalendarPoller extends EventEmitter {
     this.log(`Updating calendar ${this.name}`);
 
     https.get(this._url, (resp) => {
+
+      if (resp.headers["content-encoding"] === "gzip") {
+        var gunzip = zlib.createGunzip();
+        resp = resp.pipe(gunzip);
+      }
 
       resp.setEncoding('utf8');
       let data = '';

--- a/src/CalendarPoller.js
+++ b/src/CalendarPoller.js
@@ -57,7 +57,11 @@ class CalendarPoller extends EventEmitter {
   
       // The whole response has been received. 
       resp.on('end', () => {
-        this._refreshCalendar(data);
+        if (resp.statusCode == 200) {
+          this._refreshCalendar(data);
+        } else {
+          this.emit('error', new Error("HTTP Error " + resp.statusCode));
+        }
       });
   
     }).on('error', (err) => {


### PR DESCRIPTION
Some calendar servers (such as Apple's iCloud) only support gzip encoded transfers to save bandwidth (example URL: https://p68-calendars.icloud.com/holidays/de_de.icscsub). I implemented gzip decompression so those calendars now also work with this module.