### PR TITLE
always schedule next iteration

### DIFF
--- a/src/CalendarPoller.js
+++ b/src/CalendarPoller.js
@@ -60,8 +60,9 @@ class CalendarPoller extends EventEmitter {
         this.log(`Failed to load iCal calender: ${this.url} with error ${err}`);
         this.emit('error', err);
       }
-
     });
+
+    this._scheduleNextIteration();
   }
 
   _refreshCalendar(data) {
@@ -80,8 +81,6 @@ class CalendarPoller extends EventEmitter {
     if (cal) {
       this.emit('data', cal);
     }
-
-    this._scheduleNextIteration();
   }
 
   _scheduleNextIteration() {


### PR DESCRIPTION
On error the next iteration will never get scheduled, therefore the poller will not run again.

Signed-off-by: Jonas Keidel <jonas@jonas-keidel.de>